### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/tioactur17/7aa9aa83-ac75-4dff-be89-140c82f051c4/2afc19fd-042f-407b-9998-2dc8584881bd/_apis/work/boardbadge/c69ff305-955b-44da-80ae-8c32dfb56b05)](https://dev.azure.com/tioactur17/7aa9aa83-ac75-4dff-be89-140c82f051c4/_boards/board/t/2afc19fd-042f-407b-9998-2dc8584881bd/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/tioactur17/7aa9aa83-ac75-4dff-be89-140c82f051c4/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.